### PR TITLE
Ensure major buttons meet tap targets and block rapid taps

### DIFF
--- a/lib/presentation/common/minq_buttons.dart
+++ b/lib/presentation/common/minq_buttons.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:minq/presentation/theme/minq_theme.dart';
+
+typedef AsyncCallback = Future<void> Function();
+
+mixin AsyncActionState<T extends StatefulWidget> on State<T> {
+  bool _isProcessing = false;
+
+  bool get isProcessing => _isProcessing;
+
+  @protected
+  Future<void> runGuarded(AsyncCallback action) async {
+    if (_isProcessing) {
+      return;
+    }
+
+    setState(() {
+      _isProcessing = true;
+    });
+
+    try {
+      await action();
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isProcessing = false;
+        });
+      }
+    }
+  }
+}
+
+class MinqPrimaryButton extends StatefulWidget {
+  const MinqPrimaryButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+    this.icon,
+    this.expand = true,
+  });
+
+  final String label;
+  final AsyncCallback? onPressed;
+  final IconData? icon;
+  final bool expand;
+
+  @override
+  State<MinqPrimaryButton> createState() => _MinqPrimaryButtonState();
+}
+
+class _MinqPrimaryButtonState extends State<MinqPrimaryButton>
+    with AsyncActionState<MinqPrimaryButton> {
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    final bool disabled = widget.onPressed == null || isProcessing;
+
+    Widget buildContent() {
+      if (isProcessing) {
+        return SizedBox(
+          key: const ValueKey<String>('progress'),
+          height: tokens.spacing(6),
+          width: tokens.spacing(6),
+          child: CircularProgressIndicator(
+            strokeWidth: 3,
+            valueColor: AlwaysStoppedAnimation<Color>(tokens.surface),
+          ),
+        );
+      }
+
+      final bool hasIcon = widget.icon != null;
+      return Row(
+        key: const ValueKey<String>('label'),
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: <Widget>[
+          if (hasIcon) ...<Widget>[
+            Icon(widget.icon, size: tokens.spacing(6)),
+            SizedBox(width: tokens.spacing(2)),
+          ],
+          Flexible(
+            child: Text(
+              widget.label,
+              textAlign: TextAlign.center,
+              style: tokens.titleSmall.copyWith(color: tokens.surface),
+            ),
+          ),
+        ],
+      );
+    }
+
+    final button = FilledButton(
+      style: FilledButton.styleFrom(
+        backgroundColor: tokens.brandPrimary,
+        foregroundColor: tokens.surface,
+        minimumSize: Size.fromHeight(tokens.spacing(14)),
+        padding: EdgeInsets.symmetric(horizontal: tokens.spacing(6)),
+        shape: RoundedRectangleBorder(borderRadius: tokens.cornerXLarge()),
+        textStyle: tokens.titleSmall,
+      ),
+      onPressed: disabled
+          ? null
+          : () => runGuarded(() async {
+                await widget.onPressed!();
+              }),
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 180),
+        transitionBuilder: (Widget child, Animation<double> animation) {
+          return FadeTransition(opacity: animation, child: child);
+        },
+        child: buildContent(),
+      ),
+    );
+
+    if (widget.expand) {
+      return SizedBox(width: double.infinity, child: button);
+    }
+
+    return button;
+  }
+}

--- a/lib/presentation/screens/celebration_screen.dart
+++ b/lib/presentation/screens/celebration_screen.dart
@@ -2,6 +2,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:minq/presentation/common/minq_buttons.dart';
 import 'package:minq/presentation/theme/minq_theme.dart';
 
 class CelebrationScreen extends StatefulWidget {
@@ -152,19 +153,9 @@ class _CelebrationScreenState extends State<CelebrationScreen>
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: <Widget>[
-          FilledButton(
-            style: FilledButton.styleFrom(
-              backgroundColor: tokens.brandPrimary,
-              foregroundColor: tokens.surface,
-              minimumSize: Size(double.infinity, tokens.spacing(14)),
-              shape: RoundedRectangleBorder(
-                borderRadius: tokens.cornerXLarge(),
-              ),
-            ),
-            onPressed: () => context.go('/'),
-            child: Text(
-                                    '次のQuestへ',              style: tokens.titleSmall.copyWith(color: tokens.surface),
-            ),
+          MinqPrimaryButton(
+            label: '次のQuestへ',
+            onPressed: () async => context.go('/'),
           ),
           SizedBox(height: tokens.spacing(3)),
           TextButton(

--- a/lib/presentation/screens/pair_screen.dart
+++ b/lib/presentation/screens/pair_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:minq/presentation/common/minq_empty_state.dart';
+import 'package:minq/presentation/common/minq_buttons.dart';
 import 'package:minq/presentation/theme/minq_theme.dart';
 
 class PairScreen extends StatefulWidget {
@@ -201,30 +202,8 @@ class _PairedView extends StatelessWidget {
             style: tokens.bodySmall.copyWith(color: tokens.textMuted),
           ),
           SizedBox(height: tokens.spacing(8)),
-          ElevatedButton(
-            style: ElevatedButton.styleFrom(
-              shape: const CircleBorder(),
-              padding: EdgeInsets.all(tokens.spacing(10)),
-              backgroundColor: tokens.brandPrimary,
-              foregroundColor: tokens.surface,
-              elevation: 6,
-              shadowColor: tokens.brandPrimary.withValues(alpha: 0.32),
-            ),
-            onPressed: () {},
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: <Widget>[
-                Icon(Icons.back_hand_outlined, size: tokens.spacing(15)),
-                SizedBox(height: tokens.spacing(2)),
-                Text(
-                  'High-five',
-                  style: tokens.bodyMedium.copyWith(
-                    color: tokens.surface,
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-              ],
-            ),
+          _HighFiveButton(
+            onPressed: () async {},
           ),
           SizedBox(height: tokens.spacing(10)),
           Text(
@@ -279,3 +258,67 @@ class _QuickMessageChip extends StatelessWidget {
     );
   }
 }
+
+class _HighFiveButton extends StatefulWidget {
+  const _HighFiveButton({required this.onPressed});
+
+  final AsyncCallback onPressed;
+
+  @override
+  State<_HighFiveButton> createState() => _HighFiveButtonState();
+}
+
+class _HighFiveButtonState extends State<_HighFiveButton>
+    with AsyncActionState<_HighFiveButton> {
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+
+    return ElevatedButton(
+      style: ElevatedButton.styleFrom(
+        shape: const CircleBorder(),
+        padding: EdgeInsets.all(tokens.spacing(10)),
+        minimumSize: Size.square(tokens.spacing(28)),
+        backgroundColor: tokens.brandPrimary,
+        foregroundColor: tokens.surface,
+        elevation: 6,
+        shadowColor: tokens.brandPrimary.withValues(alpha: 0.32),
+      ),
+      onPressed: isProcessing
+          ? null
+          : () => runGuarded(() async {
+                await widget.onPressed();
+              }),
+      child: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 200),
+        transitionBuilder: (Widget child, Animation<double> animation) {
+          return FadeTransition(opacity: animation, child: child);
+        },
+        child: isProcessing
+            ? SizedBox(
+                key: const ValueKey<String>('progress'),
+                height: tokens.spacing(7),
+                width: tokens.spacing(7),
+                child: CircularProgressIndicator(
+                  strokeWidth: 3,
+                  valueColor: AlwaysStoppedAnimation<Color>(tokens.surface),
+                ),
+              )
+            : Column(
+                key: const ValueKey<String>('content'),
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: <Widget>[
+                  Icon(Icons.back_hand_outlined, size: tokens.spacing(15)),
+                  SizedBox(height: tokens.spacing(2)),
+                  Text(
+                    'High-five',
+                    style: tokens.bodyMedium.copyWith(
+                      color: tokens.surface,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ],
+              ),
+      ),
+    );
+  }

--- a/lib/presentation/screens/record_screen.dart
+++ b/lib/presentation/screens/record_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:minq/data/providers.dart';
 import 'package:minq/domain/log/quest_log.dart';
 import 'package:minq/presentation/common/minq_empty_state.dart';
+import 'package:minq/presentation/common/minq_buttons.dart';
 import 'package:minq/presentation/theme/minq_theme.dart';
 
 enum RecordErrorType { none, offline, permissionDenied, cameraFailure }
@@ -243,6 +244,101 @@ class _RecordForm extends ConsumerWidget {
           },
         ),
       ],
+    );
+  }
+}
+
+class _ProofButton extends StatefulWidget {
+  const _ProofButton({
+    required this.text,
+    required this.icon,
+    required this.isPrimary,
+    required this.onTap,
+  });
+
+  final String text;
+  final IconData icon;
+  final bool isPrimary;
+  final AsyncCallback onTap;
+
+  @override
+  State<_ProofButton> createState() => _ProofButtonState();
+}
+
+class _ProofButtonState extends State<_ProofButton>
+    with AsyncActionState<_ProofButton> {
+  @override
+  Widget build(BuildContext context) {
+    final tokens = context.tokens;
+    final Color background =
+        widget.isPrimary ? tokens.brandPrimary : tokens.surface;
+    final Color foreground =
+        widget.isPrimary ? tokens.surface : tokens.textPrimary;
+    final BorderSide borderSide = widget.isPrimary
+        ? BorderSide.none
+        : BorderSide(color: tokens.brandPrimary.withValues(alpha: 0.24));
+
+    return ConstrainedBox(
+      constraints: BoxConstraints(
+        minHeight: tokens.spacing(18),
+        minWidth: tokens.spacing(18),
+      ),
+      child: ElevatedButton(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: background,
+          foregroundColor: foreground,
+          minimumSize: Size(double.infinity, tokens.spacing(18)),
+          padding: EdgeInsets.symmetric(
+            vertical: tokens.spacing(4),
+            horizontal: tokens.spacing(4),
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: tokens.cornerLarge(),
+            side: borderSide,
+          ),
+          elevation: widget.isPrimary ? 4 : 0,
+          shadowColor: widget.isPrimary
+              ? tokens.brandPrimary.withValues(alpha: 0.32)
+              : Colors.transparent,
+        ),
+        onPressed: isProcessing
+            ? null
+            : () => runGuarded(() async {
+                  await widget.onTap();
+                }),
+        child: AnimatedSwitcher(
+          duration: const Duration(milliseconds: 200),
+          transitionBuilder: (Widget child, Animation<double> animation) {
+            return FadeTransition(opacity: animation, child: child);
+          },
+          child: isProcessing
+              ? SizedBox(
+                  key: const ValueKey<String>('progress'),
+                  height: tokens.spacing(6),
+                  width: tokens.spacing(6),
+                  child: CircularProgressIndicator(
+                    strokeWidth: 3,
+                    valueColor: AlwaysStoppedAnimation<Color>(foreground),
+                  ),
+                )
+              : Column(
+                  key: const ValueKey<String>('content'),
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Icon(widget.icon, size: tokens.spacing(9)),
+                    SizedBox(height: tokens.spacing(3)),
+                    Text(
+                      widget.text,
+                      textAlign: TextAlign.center,
+                      style: tokens.bodyMedium.copyWith(
+                        color: foreground,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+        ),
+      ),
     );
   }
 }

--- a/task.md
+++ b/task.md
@@ -43,7 +43,7 @@
 
 [x] ダークモード: コントラスト比AA以上、画像/アイコンの反転確認
 
-[ ] タップ領域: 主要ボタン 48×48px 以上、連打時の多重処理を抑止（debounce/lock）
+[x] タップ領域: 主要ボタン 48×48px 以上、連打時の多重処理を抑止（debounce/lock）
 
 [ ] 読み込み/骨組み: Shimmer/Skeleton導入（Home/Quests/Record/Pair/Stats）
 


### PR DESCRIPTION
## Summary
- add a reusable MinqPrimaryButton and AsyncActionState mixin to enforce minimum tap sizes and debounce async actions
- update Record and Pair screens to use guarded buttons with progress feedback to prevent rapid submissions
- swap the celebration CTA to the shared button implementation and mark the tap-target checklist item complete

## Testing
- Not run (flutter command unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d69e05f2908327b898d1454b2f5515